### PR TITLE
Add watchFiles support for scss imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ There are two built in loaders: ```scss``` and ```less```. Custom loaders can be
 function MyCustomLoader (input, id) {
     // input.code
     // input.map
+    // input.watchFiles
 
     return {
         code: /* transformed code as a string */,
-        map: /* source map */
+        map: /* source map */,
+        watchFiles: /* optional extra files to watch for changes */
     }
 }
 
@@ -60,7 +62,8 @@ Loaders can also be asynchronous by returning a Promise:
 function MyCustomLoader (input, id) {
     return new Promise(resolve => ({
         code: /* transformed code as a string */,
-        map: /* source map */
+        map: /* source map */,
+        watchFiles: /* optional extra files to watch for changes */
     }));
 }
 ```

--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ function createLoaderPipeline (options, assets) {
 
                 return { 
                     code: transpiled.css.toString(),
-                    map: transpiled.map.toString()
+                    map: transpiled.map.toString(),
+                    watchFiles: transpiled.stats.includedFiles || []
                 };
             });
         }
@@ -61,7 +62,8 @@ function createLoaderPipeline (options, assets) {
 
                 return { 
                     code, 
-                    map
+                    map,
+                    watchFiles: []
                 };
             });
         }
@@ -104,6 +106,7 @@ function createLoaderPipeline (options, assets) {
             });
 
             return { 
+                ...input,
                 code: csstree.generate(ast) 
             };
         });
@@ -140,6 +143,10 @@ module.exports = function (options) {
             let input = { code };
             for (let i = 0; i < pipeline.length; i++) {
                 input = await pipeline[i](input, id);
+            }
+
+            for (let dep of input.watchFiles) {
+                this.addWatchFile(dep)
             }
 
             files[id] = input.code;

--- a/index.js
+++ b/index.js
@@ -145,8 +145,10 @@ module.exports = function (options) {
                 input = await pipeline[i](input, id);
             }
 
-            for (let dep of input.watchFiles) {
-                this.addWatchFile(dep)
+            if (Array.isArray(input.watchFiles)) {
+                for (let dep of input.watchFiles) {
+                    this.addWatchFile(dep)
+                }
             }
 
             files[id] = input.code;


### PR DESCRIPTION
When not importing the css explicitly, but relying on scss `@imports` the hot-css does not trigger. By adding these files as watchFiles they are properly detected and injected. Not using less, so dont know if it provides the same data as node-sass, but should be easy to add if it does.

A bit unsure if and how you prefer this to be tested, and I cant seem to get your instanbul tests to work (not in nollup either, but there I could run mocha with the CLI). 