### PR TITLE
Add support for dart-sass

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,15 @@ function createLoaderPipeline (options, assets) {
     options.loaders.forEach(loader => {
         if (loader === 'scss') {
             pipeline.push((input, id) => {
-                let transpiled = require('node-sass').renderSync({
+                let sass = null;
+                try {
+                    sass = require('sass')
+                } catch (e) {
+                    if (e.code === 'MODULE_NOT_FOUND') {
+                        sass = require('node-sass')
+                    }
+                }
+                let transpiled = sass.renderSync({
                     data: input.code,
                     file: id,
                     outFile: id,

--- a/test/common.js
+++ b/test/common.js
@@ -11,7 +11,7 @@ let path = require('path');
 
     // Proxyquire doesn't use require function below.
     Module._load = function (mod, module) {
-        if (mod === 'node-sass') {
+        if (mod === 'node-sass' || mod === 'sass') {
             let less = req.call(module, 'less');
 
             return {


### PR DESCRIPTION
Although node-sass is deprecated only "nominally", it lags behind
dart-sass wrt functionality, and most probably it will never get
updated. This commit adds support for dart-sass while keeping support
for node-sass.